### PR TITLE
Refine encode endpoint to stream temp wav

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,12 +2,110 @@
 
 from __future__ import annotations
 
-
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Iterable, Iterator
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import PlainTextResponse, StreamingResponse
+from pydantic import BaseModel, Field
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+GGWAVE_ENCODE_ENV = "GGWAVE_ENCODE"
+GGWAVE_DECODE_ENV = "GGWAVE_DECODE"
+
+DECODE_PATTERN = re.compile(r"\[\+] Decoded message with length \d+: '(.+?)'")
+
+
+class EncodeRequest(BaseModel):
+    """Payload describing the text that should be encoded into audio."""
+
+    text: str = Field(..., description="Text that will be transformed into a WAV payload.")
+
+    @property
+    def stripped_text(self) -> str:
+        """Return the message trimmed from surrounding whitespace."""
+
+        return self.text.strip()
+
+
+def _iter_default_cli_dirs() -> Iterator[Path]:
+    """Yield directories that are likely to contain ggwave executables."""
+
+    hints = [
+        PROJECT_ROOT,
+        PROJECT_ROOT / "external" / "ggwave",
+        PROJECT_ROOT / "build",
+        PROJECT_ROOT / "build" / "_deps" / "ggwave-build",
+    ]
+    subdirs = ["", "bin", "build", "build/bin", "build/examples", "examples"]
+
+    seen: set[str] = set()
+    for base in hints:
+        for sub in subdirs:
+            candidate = base if not sub else base / sub
+            key = os.fspath(candidate)
+            if key in seen:
+                continue
+            seen.add(key)
+            yield candidate
+
+
+def _possible_binary_names(name: str) -> list[str]:
+    """Return executable names for the current platform."""
+
+    variants = {name}
+    if os.name == "nt" and not name.lower().endswith(".exe"):
+        variants.add(f"{name}.exe")
+    return sorted(variants)
+
+
+def _ensure_cli_found(*, env_var: str, names: Iterable[str]) -> Path:
+    """Locate a ggwave CLI executable.
+
+    The lookup order honours the provided environment variable first, followed by a
+    set of well-known build directories and finally the user's ``PATH``.
+    """
+
+    override = os.environ.get(env_var)
+    if override:
+        override_path = Path(override)
+        if override_path.is_file():
+            return override_path
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"The environment variable {env_var} points to '{override}', but the"
+                " executable could not be found."
+            ),
+        )
+
+    candidate_names = [candidate for name in names for candidate in _possible_binary_names(name)]
+
+    for directory in _iter_default_cli_dirs():
+        for candidate in candidate_names:
+            path_candidate = directory / candidate
+            if path_candidate.is_file():
+                return path_candidate
+
+    for candidate in candidate_names:
+        resolved = shutil.which(candidate)
+        if resolved:
+            return Path(resolved)
+
+    names_str = ", ".join(candidate_names)
+    raise HTTPException(
+        status_code=500,
+        detail=(
+            f"Unable to locate a ggwave executable. Looked for: {names_str}. "
+            f"Consider setting the {env_var} environment variable."
+        ),
+    )
 
 
 def _run_cli(command: Iterable[str], *, input_data: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
@@ -33,7 +131,26 @@ def _remove_file(path: Path) -> None:
         pass
 
 
+encoder_path = _ensure_cli_found(env_var=GGWAVE_ENCODE_ENV, names=["ggwave-to-file", "ggwave-cli"])
+decoder_path = _ensure_cli_found(env_var=GGWAVE_DECODE_ENV, names=["ggwave-from-file"])
 
+app = FastAPI(title="ALAI ggwave helpers")
+
+
+def _build_encode_command(text: str, output_path: Path) -> tuple[list[str], bytes | None]:
+    if not text:
+        raise HTTPException(status_code=400, detail="Text to encode must not be empty.")
+
+    executable = encoder_path.name.lower()
+    if "ggwave-to-file" in executable:
+        return [str(encoder_path), text, str(output_path)], None
+    if "ggwave-cli" in executable:
+        return [str(encoder_path), "--output", str(output_path)], text.encode("utf-8")
+
+    raise HTTPException(
+        status_code=500,
+        detail=f"Unsupported encoder binary '{encoder_path}'.",
+    )
 
 
 @app.post(
@@ -41,6 +158,28 @@ def _remove_file(path: Path) -> None:
     response_class=StreamingResponse,
     summary="Encode text into an ultrasonic WAV payload",
 )
+async def encode(payload: EncodeRequest) -> StreamingResponse:
+    text = payload.stripped_text
+    if not text:
+        raise HTTPException(status_code=400, detail="Text to encode must not be empty.")
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        command, input_data = _build_encode_command(text, tmp_path)
+        _run_cli(command, input_data=input_data)
+
+        audio_file = tmp_path.open("rb")
+        try:
+            response = StreamingResponse(audio_file, media_type="audio/wav")
+            response.headers["Content-Disposition"] = 'attachment; filename="payload.wav"'
+            return response
+        except Exception:
+            audio_file.close()
+            raise
+    finally:
+        _remove_file(tmp_path)
 
 
 @app.post(
@@ -52,8 +191,6 @@ async def decode(file: UploadFile = File(..., description="WAV file generated by
     contents = await file.read()
     if not contents:
         raise HTTPException(status_code=400, detail="Uploaded WAV file was empty.")
-
-
 
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_file:
         tmp_file.write(contents)
@@ -74,3 +211,4 @@ async def decode(file: UploadFile = File(..., description="WAV file generated by
 
     message = match.group(1)
     return PlainTextResponse(content=message)
+


### PR DESCRIPTION
## Summary
- rework FastAPI app to locate ggwave CLI binaries with environment overrides
- update the encode handler to write audio into a temporary WAV file and stream it back
- ensure decode continues to use the discovered CLI and shared helpers

## Testing
- python -m compileall app/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d92e0aa0bc83239cd315c0bbd72f56